### PR TITLE
Fixed phase-only, restored typed memory views.

### DIFF
--- a/cubecal/kernels/cyfull_complex.pyx
+++ b/cubecal/kernels/cyfull_complex.pyx
@@ -12,11 +12,11 @@ ctypedef fused complex3264:
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.nonecheck(False)
-def cycompute_residual(np.ndarray[complex3264, ndim=8] m,
-                       np.ndarray[complex3264, ndim=6] g,
-                       np.ndarray[complex3264, ndim=6] gh,
-                       np.ndarray[complex3264, ndim=7] o,
-                       np.ndarray[complex3264, ndim=7] r,
+def cycompute_residual(complex3264 [:,:,:,:,:,:,:,:] m,
+                       complex3264 [:,:,:,:,:,:] g,
+                       complex3264 [:,:,:,:,:,:] gh,
+                       complex3264 [:,:,:,:,:,:,:] o,
+                       complex3264 [:,:,:,:,:,:,:] r,
                        int t_int,
                        int f_int):
 
@@ -70,9 +70,9 @@ def cycompute_residual(np.ndarray[complex3264, ndim=8] m,
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.nonecheck(False)
-def cycompute_jh(np.ndarray[complex3264, ndim=8] m,
-                 np.ndarray[complex3264, ndim=6] g,
-                 np.ndarray[complex3264, ndim=8] jh,
+def cycompute_jh(complex3264 [:,:,:,:,:,:,:,:] m,
+                 complex3264 [:,:,:,:,:,:] g,
+                 complex3264 [:,:,:,:,:,:,:,:] jh,
                  int t_int,
                  int f_int):
 
@@ -113,9 +113,9 @@ def cycompute_jh(np.ndarray[complex3264, ndim=8] m,
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.nonecheck(False)
-def cycompute_jhr(np.ndarray[complex3264, ndim=8] jh,
-                  np.ndarray[complex3264, ndim=7] r,
-                  np.ndarray[complex3264, ndim=6] jhr,
+def cycompute_jhr(complex3264 [:,:,:,:,:,:,:,:] jh,
+                  complex3264 [:,:,:,:,:,:,:] r,
+                  complex3264 [:,:,:,:,:,:] jhr,
                   int t_int,
                   int f_int):
 
@@ -161,8 +161,8 @@ def cycompute_jhr(np.ndarray[complex3264, ndim=8] jh,
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.nonecheck(False)
-def cycompute_jhj(np.ndarray[complex3264, ndim=8] jh,
-                  np.ndarray[complex3264, ndim=6] jhj,
+def cycompute_jhj(complex3264 [:,:,:,:,:,:,:,:] jh,
+                  complex3264 [:,:,:,:,:,:] jhj,
                   int t_int,
                   int f_int):
 
@@ -207,9 +207,9 @@ def cycompute_jhj(np.ndarray[complex3264, ndim=8] jh,
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.nonecheck(False)
-def cycompute_jhjinv(np.ndarray[complex3264, ndim=6] jhj,
-                     np.ndarray[complex3264, ndim=6] jhjinv,
-                     np.ndarray[np.uint16_t, ndim=4, cast=True] flags,
+def cycompute_jhjinv(complex3264 [:,:,:,:,:,:] jhj,
+                     complex3264 [:,:,:,:,:,:] jhjinv,
+                     np.uint16_t [:,:,:,:] flags,
                      float eps,
                      int flagbit):
     """
@@ -269,9 +269,9 @@ def cycompute_jhjinv(np.ndarray[complex3264, ndim=6] jhj,
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.nonecheck(False)
-def cycompute_update(np.ndarray[complex3264, ndim=6] jhr,
-                     np.ndarray[complex3264, ndim=6] jhj,
-                     np.ndarray[complex3264, ndim=6] upd):
+def cycompute_update(complex3264 [:,:,:,:,:,:] jhr,
+                     complex3264 [:,:,:,:,:,:] jhj,
+                     complex3264 [:,:,:,:,:,:] upd):
     """
     This computes the update by computing the product of jhj and jhr. These should already have been
     reduced to the correct dimension so that this operation is very simple. 
@@ -307,10 +307,10 @@ def cycompute_update(np.ndarray[complex3264, ndim=6] jhr,
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.nonecheck(False)
-def cycompute_corrected(np.ndarray[complex3264, ndim=6] o,
-                        np.ndarray[complex3264, ndim=6] g,
-                        np.ndarray[complex3264, ndim=6] gh,
-                        np.ndarray[complex3264, ndim=6] corr,
+def cycompute_corrected(complex3264 [:,:,:,:,:,:] o,
+                        complex3264 [:,:,:,:,:,:] g,
+                        complex3264 [:,:,:,:,:,:] gh,
+                        complex3264 [:,:,:,:,:,:] corr,
                         int t_int,
                         int f_int):
 

--- a/cubecal/kernels/cyphase_only.pyx
+++ b/cubecal/kernels/cyphase_only.pyx
@@ -15,8 +15,8 @@ ctypedef fused float3264:
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.nonecheck(False)
-def cycompute_jhj(np.ndarray[complex3264, ndim=8] m,
-                  np.ndarray[complex3264, ndim=6] jhj,
+def cycompute_jhj(complex3264 [:,:,:,:,:,:,:,:] m,
+                  complex3264 [:,:,:,:,:,:] jhj,
                   int t_int,
                   int f_int):
 
@@ -54,9 +54,10 @@ def cycompute_jhj(np.ndarray[complex3264, ndim=8] m,
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.nonecheck(False)
-def cycompute_jhjinv(np.ndarray[complex3264, ndim=6] jhj,
-                     np.ndarray[np.uint16_t, ndim=4, cast=True] flags,
-                     float eps, int flagbit):
+def cycompute_jhjinv(complex3264 [:,:,:,:,:,:] jhj,
+                     np.uint16_t [:,:,:,:] flags,
+                     float eps, 
+                     int flagbit):
 
     cdef int d, t, f, aa, ab = 0
     cdef int n_dir, n_tim, n_fre, n_ant
@@ -84,15 +85,16 @@ def cycompute_jhjinv(np.ndarray[complex3264, ndim=6] jhj,
 
                             jhj[d,t,f,aa,0,0] = 1/jhj[d,t,f,aa,0,0]
                             jhj[d,t,f,aa,1,1] = 1/jhj[d,t,f,aa,1,1]
+    
     return flag_count
 
 @cython.cdivision(True)
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.nonecheck(False)
-def cycompute_jh(np.ndarray[complex3264, ndim=8] m,
-                 np.ndarray[complex3264, ndim=6] g,
-                 np.ndarray[complex3264, ndim=8] jh,
+def cycompute_jh(complex3264 [:,:,:,:,:,:,:,:] m,
+                 complex3264 [:,:,:,:,:,:] g,
+                 complex3264 [:,:,:,:,:,:,:,:] jh,
                  int t_int,
                  int f_int):
 
@@ -130,10 +132,10 @@ def cycompute_jh(np.ndarray[complex3264, ndim=8] m,
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.nonecheck(False)
-def cycompute_jhr(np.ndarray[complex3264, ndim=6] gh,
-                  np.ndarray[complex3264, ndim=8] jh,
-                  np.ndarray[complex3264, ndim=7] r,
-                  np.ndarray[complex3264, ndim=6] jhr,
+def cycompute_jhr(complex3264 [:,:,:,:,:,:] gh,
+                  complex3264 [:,:,:,:,:,:,:,:] jh,
+                  complex3264 [:,:,:,:,:,:,:] r,
+                  complex3264 [:,:,:,:,:,:] jhr,
                   int t_int,
                   int f_int):
 
@@ -171,9 +173,9 @@ def cycompute_jhr(np.ndarray[complex3264, ndim=6] gh,
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.nonecheck(False)
-def cycompute_update(np.ndarray[float3264, ndim=6] jhr,
-                     np.ndarray[float3264, ndim=6] jhj,
-                     np.ndarray[float3264, ndim=6] upd):
+def cycompute_update(float3264 [:,:,:,:,:,:] jhr,
+                     float3264 [:,:,:,:,:,:] jhj,
+                     float3264 [:,:,:,:,:,:] upd):
     """
     NOTE: THIS RIGHT-MULTIPLIES THE ENTRIES OF IN1 BY THE ENTRIES OF IN2.
     """
@@ -199,11 +201,11 @@ def cycompute_update(np.ndarray[float3264, ndim=6] jhr,
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.nonecheck(False)
-def cycompute_residual(np.ndarray[complex3264, ndim=8] m,
-                       np.ndarray[complex3264, ndim=6] g,
-                       np.ndarray[complex3264, ndim=6] gh,
-                       np.ndarray[complex3264, ndim=7] o,
-                       np.ndarray[complex3264, ndim=7] r,
+def cycompute_residual(complex3264 [:,:,:,:,:,:,:,:] m,
+                       complex3264 [:,:,:,:,:,:] g,
+                       complex3264 [:,:,:,:,:,:] gh,
+                       complex3264 [:,:,:,:,:,:,:] o,
+                       complex3264 [:,:,:,:,:,:,:] r,
                        int t_int,
                        int f_int):
 
@@ -245,10 +247,10 @@ def cycompute_residual(np.ndarray[complex3264, ndim=8] m,
 @cython.wraparound(False)
 @cython.boundscheck(False)
 @cython.nonecheck(False)
-def cycompute_corrected(np.ndarray[complex3264, ndim=6] o,
-                        np.ndarray[complex3264, ndim=6] g,
-                        np.ndarray[complex3264, ndim=6] gh,
-                        np.ndarray[complex3264, ndim=6] corr,
+def cycompute_corrected(complex3264 [:,:,:,:,:,:] o,
+                        complex3264 [:,:,:,:,:,:] g,
+                        complex3264 [:,:,:,:,:,:] gh,
+                        complex3264 [:,:,:,:,:,:] corr,
                         int t_int,
                         int f_int):
 

--- a/cubecal/machines/phase_diag_machine.py
+++ b/cubecal/machines/phase_diag_machine.py
@@ -16,7 +16,6 @@ class PhaseDiagGains(PerIntervalGains):
 
         self.gains = np.empty_like(self.phases, dtype=model_arr.dtype)
         self.gains[:] = np.eye(self.n_cor) 
-        self.gflags    = np.zeros(self.flag_shape, dtype=np.uint8)
 
     def compute_js(self, obser_arr, model_arr):
         """
@@ -141,6 +140,6 @@ class PhaseDiagGains(PerIntervalGains):
 
         cyphase.cycompute_jhj(model_arr, self.jhjinv, self.t_int, self.f_int)
 
-        cyphase.cycompute_jhjinv(self.jhjinv, self.gflags, self.eps)
+        cyphase.cycompute_jhjinv(self.jhjinv, self.gflags, self.eps, self.flagbit)
 
         self.jhjinv = self.jhjinv.real

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,11 @@ import os
 from setuptools import setup
 from setuptools.extension import Extension
 from Cython.Build import cythonize
+import Cython.Compiler.Options as CCO
 from setuptools.command.install import install
 import numpy as np			
+
+CCO.buffer_max_dims = 9
 
 class custom_install(install):
 	def run(self):


### PR DESCRIPTION
This should restore the improved performance of typed memory views. The phase-only mode also appears to be working for me after a couple of fixes. @o-smirnov, please ok this pull.