### PR TITLE
Fixing python-casacore to version 2.1.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy >= 1.11.3
 cython >= 0.25.2
 futures >= 3.0.5
-python-casacore >= 2.1.2
+python-casacore == 2.1.2

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ else:
     requirements = ['numpy', 
                     'cython', 
                     'futures', 
-                    'python-casacore', 
+                    'python-casacore==2.1.2', 
                     'sharedarray', 
                     'matplotlib',
                     'scipy',


### PR DESCRIPTION
Maintain compatibility with radio-astro (14.04) and KERN2 (16.04) PPAs. Will revise when a better solution is available.