### PR TITLE
fixes #75 again. Hopefully for good.

### DIFF
--- a/cubical/tools/logger.py
+++ b/cubical/tools/logger.py
@@ -221,6 +221,7 @@ def init(app_name):
         logging.basicConfig(level=logging.DEBUG, fmt=_fmt, datefmt=_datefmt)
         _app_name = app_name
         _root_logger = logging.getLogger(app_name)
+        _root_logger.setLevel(logging.DEBUG)
         global log
         log = _loggers[''] = LoggerWrapper(_root_logger)
 


### PR DESCRIPTION
OK, as you can see from the below, I previously fixed #75 only in spirit... did all the hard work decoupling the cubical root logger from the system root logger (which vext plays with), and forgot the one line that sets its log level correctly. 

Anyway @JSKenyon please confirm, should be immune to vext silliness now.
