### PR TITLE
Close FitsBeamSourceProvider when tile is saved.

### DIFF
--- a/cubical/data_handler/ms_tile.py
+++ b/cubical/data_handler/ms_tile.py
@@ -26,6 +26,7 @@ try:
 except ImportError:
     DicoSourceProvider = None
 
+
 ## TERMINOLOGY:
 ## A "chunk" is data for one DDID, a range of timeslots (thus, a subset of the MS rows), and a
 ## slice of channels. Chunks are the basic parallelization unit. Solver deals with a chunk of data.
@@ -275,8 +276,8 @@ class MSTile(object):
                                                  clear_start=False, clear_stop=False)
                 if self.tile.dh.beam_pattern:
                     self._mb_arbeam_src = FitsBeamSourceProvider(self.tile.dh.beam_pattern,
-                                                        self.tile.dh.beam_l_axis,
-                                                        self.tile.dh.beam_m_axis)
+                                                                 self.tile.dh.beam_l_axis,
+                                                                 self.tile.dh.beam_m_axis)
                 else:
                     self._mb_arbeam_src = None
 
@@ -1388,6 +1389,11 @@ class MSTile(object):
                     flag_row = flag_col.all(axis=(-1, -2))
                     print("  skipping FLAG column per user request ({:.2%} visibilities would have been flagged otherwise)".format(totflags / float(flag_col.size)), file=log)
                     print("  skipping FLAG_ROW column per user request ({:.2%} rows would have been flagged otherwise)".format(flag_row.sum() / float(flag_row.size)), file=log)
+
+            # Close the FitsBeamSourceProvider.
+            if hasattr(subset, "_mb_arbeam_src"):
+                subset._mb_arbeam_src.close()
+
             if final:
                 self.dh.finalize()
                 self.dh.unlock()

--- a/cubical/data_handler/ms_tile.py
+++ b/cubical/data_handler/ms_tile.py
@@ -1392,7 +1392,7 @@ class MSTile(object):
                     print("  skipping FLAG_ROW column per user request ({:.2%} rows would have been flagged otherwise)".format(flag_row.sum() / float(flag_row.size)), file=log)
 
             # Close the Montblanc providers, if any
-            for provider in subset._mb_measet_src, subset._mb_cached_ms_src:
+            for provider in (subset._mb_measet_src, subset._mb_cached_ms_src):
                 if provider is not None:
                     provider.close()
 

--- a/cubical/data_handler/ms_tile.py
+++ b/cubical/data_handler/ms_tile.py
@@ -109,7 +109,10 @@ class MSTile(object):
                 self.rebin_chan_map = np.arange(0, len(tile.dh.chanfreqs[self.first_ddid]), dtype=np.int64)
 
             # filled in by self.load_montblanc_models below
-            self._mb_measet_src = None
+            self._mb_measet_src = self._mb_cached_ms_src = None
+
+        # static member will be initialized with FitsBeamSourceProvider if needed
+        _mb_arbeam_src = None
 
         def upsample(self, data):
             """Helper method. Upsamples an array back to full resolution"""
@@ -274,12 +277,10 @@ class MSTile(object):
                 self._mb_cached_ms_src = CachedSourceProvider(self._mb_measet_src,
                                                  cache_data_sources=cache_data_sources,
                                                  clear_start=False, clear_stop=False)
-                if self.tile.dh.beam_pattern:
+                if self.tile.dh.beam_pattern and self._mb_arbeam_src is None:
                     self._mb_arbeam_src = FitsBeamSourceProvider(self.tile.dh.beam_pattern,
                                                                  self.tile.dh.beam_l_axis,
                                                                  self.tile.dh.beam_m_axis)
-                else:
-                    self._mb_arbeam_src = None
 
             print("  computing visibilities for {}".format(model_source), file=log(0))
             # setup Montblanc computation for this LSM
@@ -1390,13 +1391,17 @@ class MSTile(object):
                     print("  skipping FLAG column per user request ({:.2%} visibilities would have been flagged otherwise)".format(totflags / float(flag_col.size)), file=log)
                     print("  skipping FLAG_ROW column per user request ({:.2%} rows would have been flagged otherwise)".format(flag_row.sum() / float(flag_row.size)), file=log)
 
-            # Close the FitsBeamSourceProvider.
-            if hasattr(subset, "_mb_arbeam_src"):
-                subset._mb_arbeam_src.close()
+            # Close the Montblanc providers, if any
+            for provider in subset._mb_measet_src, subset._mb_cached_ms_src:
+                if provider is not None:
+                    provider.close()
 
             if final:
                 self.dh.finalize()
                 self.dh.unlock()
+                # close the singleton beam provider
+                if subset._mb_arbeam_src is not None:
+                    subset._mb_arbeam_src.close()
 
     def release(self, final=False):
         """ Releases the shared memory data dicts. """


### PR DESCRIPTION
This is a very basic fix for #398. My attempts to create a singleton have been unsuccessful thus far, but this does ensure that there are at most only two `FitsBeamSourceProviders` active at any time. @o-smirnov can you please give it a test run on the data which revealed the problem?