### PR TITLE
Fixes #395.

### DIFF
--- a/cubical/data_handler/TiggerSourceProvider.py
+++ b/cubical/data_handler/TiggerSourceProvider.py
@@ -143,7 +143,7 @@ class TiggerSourceProvider(SourceProvider):
         # (npsrc, ntime, nchan, 4)
         stokes = np.empty(context.shape, context.dtype)
 
-        f = self._freqs[lc:uc]
+        f = self._freqs[lc:uc].ravel()
 
         for ind, source in enumerate(self._pnt_sources[lp:up]):
             spectrum = self.source_spectrum(source, f)[None, :]
@@ -180,17 +180,15 @@ class TiggerSourceProvider(SourceProvider):
         # (npsrc, ntime, nchan, 4)
         stokes = np.empty(context.shape, context.dtype)
 
-        f = self._freqs[lc:uc]
+        f = self._freqs[lc:uc].ravel()
 
         for ind, source in enumerate(self._gau_sources[lg:ug]):
             spectrum = self.source_spectrum(source, f)[None, :]
 
             # Multiply flux into the spectrum,
             # broadcasting into the time dimension
-            stokes[ind, :, :, 0] = source.flux.I*spectrum
-            stokes[ind, :, :, 1] = source.flux.Q*spectrum
-            stokes[ind, :, :, 2] = source.flux.U*spectrum
-            stokes[ind, :, :, 3] = source.flux.V*spectrum
+            for iS, S in enumerate('IQUV'):
+                stokes[ind, :, :, iS] = getattr(source.flux, S, 0.)*spectrum
 
         return stokes
 

--- a/cubical/workers.py
+++ b/cubical/workers.py
@@ -3,6 +3,7 @@ from builtins import range
 import multiprocessing, os, sys, traceback
 import concurrent.futures as cf
 import re
+import numba
 
 
 import cubical.kernels
@@ -117,7 +118,7 @@ def setup_parallelism(ncpu, nworker, nthread, force_serial, affinity, io_affinit
     if not parallel:
         if nthread:
             cubical.kernels.num_omp_threads = nthread
-            os.environ["NUMBA_NUM_THREADS"] = str(nthread)
+            numba.set_num_threads(int(nthread))
             os.environ["OMP_NUM_THREADS"] = os.environ["OMP_THREAD_LIMIT"] = str(nthread)
         return False
 
@@ -127,7 +128,7 @@ def setup_parallelism(ncpu, nworker, nthread, force_serial, affinity, io_affinit
     # child processes will inherit this
     cubical.kernels.num_omp_threads = nthread
 
-    os.environ["NUMBA_NUM_THREADS"] = str(nthread)
+    numba.set_num_threads(int(nthread))
 
     # parse affinity argument
     if affinity != "" and affinity is not None:


### PR DESCRIPTION
Using environment variables to configure numba threading behaviour causes segfaults as of `0.49.0`. I have replaced this behaviour with `numba.set_num_threads()` which is newer and works as expected.