### PR TITLE
Issue 431

### DIFF
--- a/cubical/data_handler/MBTiggerSim.py
+++ b/cubical/data_handler/MBTiggerSim.py
@@ -234,7 +234,7 @@ class ColumnSinkProvider(SinkProvider):
             ur = upper + offset
             lc = ddid_ind*self._chan_per_ddid
             uc = (ddid_ind+1)*self._chan_per_ddid
-            self._model[self._dir, 0, lr:ur, :, :] = \
+            self._model[self._dir, 0, lr:ur, :, :] += \
                     context.data[:,:,lc:uc,sel].reshape(-1, self._chan_per_ddid, self._ncorr)
 
     def __str__(self):

--- a/cubical/data_handler/ms_tile.py
+++ b/cubical/data_handler/ms_tile.py
@@ -303,7 +303,7 @@ class MSTile(object):
                     tigger_source.set_frequency(self._freqs)
                     column_snk.set_direction(direction)
                     if self._mb_arbeam_src and req_beam == "beam":
-                        dir_srcs = [*srcs, self._mb_arbeam_src]
+                        dir_srcs = srcs + [self._mb_arbeam_src]
                     else:
                         dir_srcs = srcs
                     MBTiggerSim.simulate(dir_srcs,

--- a/cubical/data_handler/ms_tile.py
+++ b/cubical/data_handler/ms_tile.py
@@ -287,8 +287,6 @@ class MSTile(object):
             tigger_source = model_source
             cached_src = CachedSourceProvider(tigger_source, clear_start=True, clear_stop=True)
             srcs = [self._mb_cached_ms_src, cached_src]
-            if self._mb_arbeam_src:
-                srcs.append(self._mb_arbeam_src)
 
             # make a sink with an array to receive visibilities
             ndirs = model_source._nclus

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setup(name='cubical',
                'cubical/bin/plot-gain-solutions'],
       entry_points={'console_scripts': ['gocubical = cubical.main:main']},
       extras_require={
-          'lsm-support': ['montblanc @git+https://github.com/ska-sa/montblanc.git@0.6.1'],
+          'lsm-support': ['montblanc@git+https://github.com/ska-sa/montblanc.git@0.6.1'],
           'degridder-support': ['ddfacet >= 0.5.0', 
                                 'regions >= 0.4',
                                 'meqtrees-cattery >= 1.7.0']

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setup(name='cubical',
                'cubical/bin/plot-gain-solutions'],
       entry_points={'console_scripts': ['gocubical = cubical.main:main']},
       extras_require={
-          'lsm-support': ['montblanc@git+https://github.com/ska-sa/montblanc.git@0.6.1'],
+          'lsm-support': ['montblanc@git+https://github.com/ska-sa/montblanc.git@0.6.4'],
           'degridder-support': ['ddfacet >= 0.5.0', 
                                 'regions >= 0.4',
                                 'meqtrees-cattery >= 1.7.0']


### PR DESCRIPTION
This will make the predict honour nobeam tags in the lsm. Note that this is always on - if you have nobeam sources, make sure they retain their apparent flux values in the model. My own tests suggest that this works correctly, but please raise issues If there is a major performance degradation or something I missed.