### PR TITLE
fixes-459

### DIFF
--- a/cubical/DefaultParset.cfg
+++ b/cubical/DefaultParset.cfg
@@ -181,7 +181,8 @@ FITSMAxis           	= Y      # M axis of FITS file. Minus sign indicates revers
 FITSVerbosity       	= 0      # set to >0 to have verbose output from FITS interpolator classes. #metavar:LEVEL #type:int
 FeedAngle               = 0      # offset feed angle to add to parallactic angle #type:float
 FlipVisibilityHands     = 0      # apply anti-diagonal matrix if FITS beam is enabled effectively swapping X and Y or R and L and their respective hands
-
+PointingCenterAt        = "DataPhaseDir" #DataPhaseDir if the models should be phased to the phasecentre as stored in the MS, otherwise may specify
+  epoch,ra,dec here where epoch should be j2000, ra a value in hms format, and dec in sdms format
 [postmortem]
 _Help             = Options for "postmortem" flagging based on solution statistics
 enable            = 0           # If True, will do an extra round of flagging at the end based on solution statistics

--- a/cubical/degridder/DDFacetSim.py
+++ b/cubical/degridder/DDFacetSim.py
@@ -31,6 +31,9 @@ import hashlib
 import datetime as dt
 import pyrap.quanta as pq
 from numba import jit, prange
+import concurrent.futures as cf
+import cubical.workers as cw
+import multiprocessing
 
 def init_degridders(dir_CFs, 
                     dir_DCs,
@@ -48,6 +51,11 @@ def init_degridders(dir_CFs,
                     GD,
                     gmachines=None):
     """ Dummy initialization method to be executed on process pool """
+    if cw.num_threads > 1:
+        old_omp_setting = os.environ.get("OMP_NUM_THREADS", str(multiprocessing.cpu_count()))
+        # OMP is not fork safe.... we have to force serialization in case the solvers are already set up
+        # to use threading
+        os.environ["OMP_NUM_THREADS"] = "1"
     dir_CFs = dir_CFs.instantiate()
     dir_DCs = dir_DCs.instantiate()
     CFs_dict = CFs_dict.instantiate()
@@ -69,6 +77,9 @@ def init_degridders(dir_CFs,
         wnd_detaper = MT.Sphe2D(npix)
         wnd_detaper[wnd_detaper != 0] = 1.0 / wnd_detaper[wnd_detaper != 0]
         dir_DCs["facet_{}".format(dir_CFs[dname][subregion_index])] = wnd_detaper
+
+    if cw.num_threads > 1:
+        os.environ["OMP_NUM_THREADS"] = old_omp_setting
 
 global UNIQ_ID
 try:
@@ -102,7 +113,8 @@ class DDFacetSim(object):
     @classmethod
     def initialize_pool(cls, num_processes=0):
         if num_processes > 1:
-            DDFacetSim.__exec_pool = PPE(max_workers=num_processes)
+            if DDFacetSim.__exec_pool is None:
+                DDFacetSim.__exec_pool = PPE(max_workers=num_processes)
             DDFacetSim.__IN_PARALLEL_INIT = True
 
     @classmethod
@@ -449,7 +461,7 @@ class DDFacetSim(object):
                     shared_dict.SharedDict("convfilters.cubidegrid.{}.{}.{}".format(UNIQ_ID, dname, sri))
 
         # init in parallel
-        futures = []        
+        futures = {}        
         for subregion_index in range(src.subregion_count):
             ra, dec = np.deg2rad(src.get_direction_pxoffset(subregion_index=subregion_index) * 
                                     src.pixel_scale / 3600.0) + self.__phasecenter
@@ -469,15 +481,24 @@ class DDFacetSim(object):
                         wmax,
                         GD)
             if DDFacetSim.__IN_PARALLEL_INIT:
-                futures.append(DDFacetSim.__exec_pool.submit(init_degridders, *init_args))
+                futures[DDFacetSim.__exec_pool.submit(init_degridders, *init_args)] = subregion_index
             else:
                 init_degridders(*init_args)
 
         if DDFacetSim.__IN_PARALLEL_INIT:
-            for f in futures:
-                expt = f.exception()
-                if expt is not None:
-                    raise expt
+            def reap_children():
+                pid, status, _ = os.wait3(os.WNOHANG)
+                if pid:
+                    print("child process {} exited with status {}. This is a bug, or an out-of-memory condition.".format(pid, status), file=log(0,"red"))
+                    print("This error is not recoverable: the main process will now commit ritual harakiri.", file=log(0,"red"))
+                    os._exit(1)
+            while futures:
+                reap_children()
+                done, not_done = cf.wait(list(futures.keys()), timeout=1)
+                for future in done:
+                    key = futures[future]
+                    stats = future.result()
+                    del futures[future]
         
         # construct handles after the initialization has been completed
         for subregion_index in range(src.subregion_count):
@@ -567,7 +588,12 @@ class DDFacetSim(object):
                                         station_positions = dh.antpos,
                                         utc_times = utc_times,
                                         provider=dh.degrid_opts["BeamModel"])
-
+            if cw.num_threads > 1:
+                old_omp_setting = os.environ.get("OMP_NUM_THREADS", str(multiprocessing.cpu_count()))
+                # OMP is not fork safe.... we have to force serialization in case the solvers are already set up
+                # to use threading
+                os.environ["OMP_NUM_THREADS"] = "1"
+            
             this_region_model = -1 * gm.get( #default of the degridder is to subtract from the previous model
                 times=tile_subset.time_col, 
                 uvw=uvwco.astype(dtype=np.float64).copy(), 
@@ -583,11 +609,14 @@ class DDFacetSim(object):
                 TranformModelInput="FT", 
                 ChanMapping=np.array(freq_mapping, dtype=np.int32), 
                 sparsification=None)
-            
+
             region_model += self.__apply_jones(vis = this_region_model,
                                                jones_matrix = E_jones,
                                                a0 = tile_subset.antea,
                                                a1 = tile_subset.anteb)
+            
+            if cw.num_threads > 1:
+                os.environ["OMP_NUM_THREADS"] = old_omp_setting
 
         model_corr_slice = np.s_[0] if model_type == "cplxscalar" else \
                            np.s_[0::3] if model_type == "cplxdiag" else \

--- a/cubical/plots/ifrgains.py
+++ b/cubical/plots/ifrgains.py
@@ -251,7 +251,7 @@ def make_ifrgain_plots(ig, ms, GD, basename):
         pylab.subplot(NR, NC, 2)
         plot_ants([(p, igpa[p]) for p in antennas], "IFR %s %s gain amplitudes per antenna" % FEEDS)
         if baseline:
-            pylab.subplot(NR, NC/2, 3)
+            pylab.subplot(NR, NC//2, 3)
             plot_baseline(norm_igs, baseline, "IFR gain amplitude vs. baseline length", FEEDS)
         save_figure("bbc-{}".format(label), width*NC, height*NR)
 

--- a/cubical/workers.py
+++ b/cubical/workers.py
@@ -117,7 +117,7 @@ def setup_parallelism(ncpu, nworker, nthread, force_serial, affinity, io_affinit
     global num_threads
     def set_numba_threading(nthread):
         try:
-            numba.config.THREADING_LAYER = "tbb"
+            numba.config.THREADING_LAYER = "safe"
             @numba.njit(parallel=True)
             def foo(a, b):
                 return a + b
@@ -125,8 +125,8 @@ def setup_parallelism(ncpu, nworker, nthread, force_serial, affinity, io_affinit
             return nthread
         except:
             numba.config.THREADING_LAYER = "workqueue"
-            print("Cannot use TBB threading (check your installation). Reverting to workqueue parallelization.", file=log(0, "red"))
-            return nthread
+            print("Cannot use TBB threading (check your installation). Reverting to workqueue parallelization and dropping to 1 thread per worker in solvers", file=log(0, "red"))
+            return 1
     nthread = set_numba_threading(nthread)
     parallel, num_workers, nthread = _setup_workers_and_threads(force_serial, ncpu, nworker, nthread,
                                                                 montblanc_threads if use_montblanc else None, max_workers)  

--- a/cubical/workers.py
+++ b/cubical/workers.py
@@ -121,7 +121,7 @@ def setup_parallelism(ncpu, nworker, nthread, force_serial, affinity, io_affinit
             return nthread
         except:
             numba.config.THREADING_LAYER = "default"
-            print("Cannot use TDD threading (check your installation). Dropping the number of solver threads to 1", file=log(0, "red"))
+            print("Cannot use TBB threading (check your installation). Dropping the number of solver threads to 1", file=log(0, "red"))
             return 1
     nthread = set_numba_threading(nthread)
     parallel, num_workers, nthread = _setup_workers_and_threads(force_serial, ncpu, nworker, nthread,

--- a/cubical/workers.py
+++ b/cubical/workers.py
@@ -16,7 +16,10 @@ log = logger.getLogger("main")
 worker_process_properties = dict(MainProcess={})
 
 # number of worker processes that will be run
+global num_workers
 num_workers = 0
+global num_threads
+num_threads = 0
 
 def _setup_workers_and_threads(force_serial, ncpu, nworkers, nthreads, montblanc_threads, max_workers):
     """
@@ -111,21 +114,23 @@ def setup_parallelism(ncpu, nworker, nthread, force_serial, affinity, io_affinit
         True if parallel mode is invoked (i.e. workers are to be launched)
     """
     global num_workers
+    global num_threads
     def set_numba_threading(nthread):
         try:
-            numba.config.THREADING_LAYER = "safe"
+            numba.config.THREADING_LAYER = "tbb"
             @numba.njit(parallel=True)
             def foo(a, b):
                 return a + b
             foo(np.arange(5), np.arange(5))
             return nthread
         except:
-            numba.config.THREADING_LAYER = "default"
-            print("Cannot use TBB threading (check your installation). Dropping the number of solver threads to 1", file=log(0, "red"))
-            return 1
+            numba.config.THREADING_LAYER = "workqueue"
+            print("Cannot use TBB threading (check your installation). Reverting to workqueue parallelization.", file=log(0, "red"))
+            return nthread
     nthread = set_numba_threading(nthread)
     parallel, num_workers, nthread = _setup_workers_and_threads(force_serial, ncpu, nworker, nthread,
-                                                                montblanc_threads if use_montblanc else None, max_workers)        
+                                                                montblanc_threads if use_montblanc else None, max_workers)  
+    num_threads = nthread 
     # in serial mode, simply set the Montblanc and/or worker thread count, and return
     if not parallel:
         if nthread:


### PR DESCRIPTION
This fixes #459.

As near as I can tell the issue is in the use of threads inside numba..... TDD fails to import in the new numba (even if I follow their instructions and install from pip.... @JSKenyon)

I still can't track down this super annoying error -- that part of the code is a bit cryptic maybe @o-smirnov can be of some assistance here
```
INFO      19:19:39 - data_handler       [x01] [0.3/2.2 2.6/23.0 0.9Gb] reading BITFLAG
INFO      19:19:39 - main               [0.2/2.9 2.1/25.8 0.9Gb] WARNING: unrecognized worker process name 'Process-6'. Please inform the developers.
```

At least it runs through again now

Running with
```
gocubical --sol-jones g,dd --data-ms msdir/1491291289.1ghz.1.1ghz.4hrs.ms --data-column CORRECTED_DATA --data-time-chunk 8 --data-freq-chunk 0 --model-list "MODEL_DATA+-output/deep2.DicoModel@msdir/tag.reg:output/deep2.DicoModel@msdir/tag.reg" --model-ddes auto --weight-column WEIGHT --flags-apply FLAG --flags-auto-init legacy --madmax-enable 0 --madmax-global-threshold 0,0 --madmax-threshold 0,0,10 --sol-stall-quorum 0.95 --sol-term-iters 50,90,50,90 --sol-min-bl 110.0 --sol-max-bl 0 --dist-max-chunks 4 --out-name output/deep2cal --out-overwrite 1 --out-mode sr --out-column DE_DATA --out-subtract-dirs 1:  --g-time-int 8 --g-freq-int 0 --g-clip-low 0 --g-clip-high 0 --g-type complex-diag --g-update-type phase-diag --g-max-prior-error 0.35 --g-max-post-error 0.35 --g-max-iter 100 --dd-dd-term 1 --dd-time-int 8 --dd-freq-int 32 --dd-clip-low 0 --dd-clip-high 0 --dd-type complex-diag --dd-fix-dirs 0 --dd-max-prior-error 0.35 --dd-max-post-error 0.35 --dd-max-iter 200 --degridding-OverS 11 --degridding-Support 7 --degridding-Nw 100 --degridding-wmax 0 --degridding-Padding 1.7 --degridding-NDegridBand 15 --degridding-MaxFacetSize 0.15 --degridding-MinNFacetPerAxis 1 --dist-nthread 4 --dist-nworker 4 --dist-ncpu 4
```