### PR TITLE
Unify FITSBeamInterpolator with DDFacet ClassFITSBeam

### DIFF
--- a/cubical/DefaultParset.cfg
+++ b/cubical/DefaultParset.cfg
@@ -162,7 +162,6 @@ NDegridBand    = 16  # Number of image bands for degridding. 0 means degrid each
 MaxFacetSize   = 0.25 # Maximum facet size in degrees
 MinNFacetPerAxis  = 1   # Minimum number of facets per direction
 NProcess = 8            # Number of subprocesses to use in degridding-based predict
-
 BeamModel		    	= None      # Beam model to use. #options:None|FITS
 NBand               	= 0         # Number of channels over which same beam value is used. 0 means use every channel. #metavar:N #type:int
 FITSFile            	= beam_$(corr)_$(reim).fits # Beam FITS file pattern. A beam pattern consists of eight FITS files, i.e. a real and imaginary
@@ -171,6 +170,42 @@ FITSFile            	= beam_$(corr)_$(reim).fits # Beam FITS file pattern. A bea
   is replaced by "real" or "imag". Uppercase variables are replaced by uppercase values, e.g. $(REIM) by "RE" pr "IM".
   Use "unity" if you want to apply a unity matrix for the E term (e.g. only want to do visibility derotations).
   Correlation labels (XY or RL) are determined by reading the MS, but may be overridden by the FITSFeed option.
+  To use a heterogeneous mix of beams you have to first type specialize the antennas using a json configuration of
+  the following format:
+  {'lband': {
+        'patterns': {
+            'cmd::default': ['${stype}_${corr}_${reim}.fits',...],
+        },
+        'define-stationtypes': {
+            'cmd::default': 'meerkat',
+                'ska000': 'ska'
+        } 
+    },
+    ...
+  }
+  This will substitute 'meerkat' for all antennas but ska000, with 'meerkat_${corr}_${reim}.fits'
+  whereas beams for ska000 will be loaded from 'ska_${corr}_${reim}.fits' in this example.
+  The station name may be specified as regex by adding a '~' infront of the pattern to match, e.g
+  '~ska[0-9]{3}': 'ska' will assgign all the 'ska' type to all matching names such as ska000, ska001, ..., skaNNN.
+  Each station type in the pattern section may specify a list of patterns for different frequency ranges.
+  Multiple keyed dictionaries such as this may be specified within one file. They will be treated as chained
+  configurations, adding more patterns and station-types to the first such block.
+  Warning: Once a station is type-specialized the type applies to **ALL** chained blocks!
+  Blocks from more than one config file can be loaded by comma separation, e.g.
+  '--Beam-FITSFile conf1.json,conf2.json,...', however no block may define multiple types for any station.
+  If patterns for a particular station type already exists more patterns are just appended to the existing list.
+  Warning: where multiple patterns specify the same frequency range the first such pattern closest to the MS
+  SPW frequency coverage will be loaded.
+  If no configuration file is provided the pattern may not contain ${stype} -- station independence is assumed.
+  This is the same as specifing the following config:
+  {'lband': {
+      'patterns': {
+          'cmd::default': ['${corr}_${reim}.fits',...],
+      },
+      'define-stationtypes': {
+          'cmd::default': 'cmd::default'
+      }
+  }
   #metavar:PATTERN
 FITSFeed		= None   # If set, overrides correlation labels given by the measurement set. #options:None|xy|XY|rl|RL
 FITSFeedSwap		= False	 # swap feed patterns (X to Y and R to L) #type:bool
@@ -179,7 +214,10 @@ FITSParAngleIncDeg  	= 5      # increment in PA in degrees at which the beam is 
 FITSLAxis           	= -X     # L axis of FITS file. Minus sign indicates reverse coordinate convention. #metavar:AXIS #type:str
 FITSMAxis           	= Y      # M axis of FITS file. Minus sign indicates reverse coordinate convention. #metavar:AXIS #type:str
 FITSVerbosity       	= 0      # set to >0 to have verbose output from FITS interpolator classes. #metavar:LEVEL #type:int
+FITSFrame               = altaz  # coordinate frame for FITS beams. Currently, alt-az, equatorial and zenith mounts are supported.
+                                  #options:altaz|altazgeo|equatorial|zenith #metavar:FRAME
 FeedAngle               = 0      # offset feed angle to add to parallactic angle #type:float
+ApplyPJones             = 0      # derotate visibility data (only when FITS beam is active and also time sampled)
 FlipVisibilityHands     = 0      # apply anti-diagonal matrix if FITS beam is enabled effectively swapping X and Y or R and L and their respective hands
 PointingCenterAt        = "DataPhaseDir" #DataPhaseDir if the models should be phased to the phasecentre as stored in the MS, otherwise may specify
   epoch,ra,dec here where epoch should be j2000, ra a value in hms format, and dec in sdms format

--- a/cubical/degridder/FITSBeamInterpolator.py
+++ b/cubical/degridder/FITSBeamInterpolator.py
@@ -1,43 +1,24 @@
-'''
-DDFacet, a facet-based radio imaging package
-Copyright (C) 2013-2016  Cyril Tasse, l'Observatoire de Paris,
-SKA South Africa, Rhodes University
-
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
-of the License, or (at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
-This file has been ported to CubiCal by the original authors, with minor modifications.
-'''
-
+# CubiCal: a radio interferometric calibration suite
+# (c) 2017 Rhodes University & Jonathan S. Kenyon
+# http://github.com/ratt-ru/CubiCal
+# This code is distributed under the terms of GPLv2, see LICENSE.md for details
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from multiprocessing.sharedctypes import Value
 
 from DDFacet.compatibility import range
-
+import DDFacet.Data.ClassFITSBeam as DDFacetFITSBeam
+import DDFacet.Data.ClassMS as DDFacetClassMS
 import numpy
 import os
 import os.path
 import sys
+import pyrap.tables
+import numpy as np
 
 from cubical.tools import logger, ModColor
 log = logger.getLogger("FITSBeamInterpolator")
-
-import pyrap.tables
-
-import numpy as np
-
 
 dm = pyrap.measures.measures()
 dq = pyrap.quanta
@@ -45,15 +26,44 @@ dq = pyrap.quanta
 # This a list of the Stokes enums (as defined in casacore header measures/Stokes.h)
 # These are referenced by the CORR_TYPE column of the MS POLARIZATION subtable.
 # E.g. 5,6,7,8 corresponds to RR,RL,LR,LL
-MS_STOKES_ENUMS = [
-    "Undefined", "I", "Q", "U", "V", "RR", "RL", "LR", "LL", "XX", "XY", "YX", "YY", "RX", "RY", "LX", "LY", "XR", "XL", "YR", "YL", "PP", "PQ", "QP", "QQ", "RCircular", "LCircular", "Linear", "Ptotal", "Plinear", "PFtotal", "PFlinear", "Pangle"
-  ];
+MS_STOKES_ENUMS = DDFacetFITSBeam.MS_STOKES_ENUMS
 # set of circular correlations
-CIRCULAR_CORRS = set(["RR", "RL", "LR", "LL"]);
+CIRCULAR_CORRS = DDFacetFITSBeam.CIRCULAR_CORRS
 # set of linear correlations
-LINEAR_CORRS = set(["XX", "XY", "YX", "YY"]);
+LINEAR_CORRS = DDFacetFITSBeam.LINEAR_CORRS
 
-
+class DDFacetMSLite:
+    def __init__ (self,
+                  field_centre,
+                  chunk_ctr_frequencies,
+                  chunk_channel_widths,
+                  correlation_ids,
+                  station_positions,
+                  station_names):
+        """
+            Standin object for the ClassMS visibility reader of DDFacet
+            field_centre: radian ra dec coordinate of the original field phase centre
+            chunk_ctr_frequencies: center channel frequencies (Hz) of chunk to predict E terms for
+            chunk_channel_widths: channel widths of chunk channels
+            correlation_ids: hand labels per correlation term as defined in casacore Stokes.h
+            station_positions: ECEF coordinates for stations (na, 3) array
+            station_names: Station names
+        """
+        self.ChanFreq = chunk_ctr_frequencies
+        self.OriginalRadec = field_centre
+        self.ChanWidth = chunk_channel_widths
+        self.CorrelationNames = list(map(lambda x: MS_STOKES_ENUMS[x], 
+                                         sorted(correlation_ids)))
+        self.StationNames = station_names
+        self.na = len(station_names)
+        self.StationPos = station_positions
+        self.rarad, self.decrad = self.OriginalRadec
+        if len(self.StationNames) != len(self.StationPos):
+            raise ValueError("StationNames should be the length of StationPos")
+        
+    def radec2lm_scalar(self, *args, **kwargs):
+        return DDFacetClassMS.ClassMS.radec2lm_scalar(self, *args, **kwargs)
+        
 class FITSBeamInterpolator (object):
     def __init__ (self, 
                   field_centre,
@@ -61,301 +71,28 @@ class FITSBeamInterpolator (object):
                   chunk_channel_widths,
                   correlation_ids,
                   station_positions,
+                  station_names,
                   opts):
         """
+            Proxy object for DDFacet.ClassFITSBeam
             field_centre: radian ra dec coordinate of the original field phase centre
             chunk_ctr_frequencies: center channel frequencies (Hz) of chunk to predict E terms for
             chunk_channel_widths: channel widths of chunk channels
             correlation_ids: hand labels per correlation term as defined in casacore Stokes.h
             station_positions: ECEF coordinates for stations (na, 3) array
+            station_names: Station names
             opts: beam opts as defined in Parset
         """
-        # filename is potentially a list (frequencies will be matched)
-        self.beamsets = opts["FITSFile"]
-        if type(self.beamsets) is not list:
-            self.beamsets = self.beamsets.split(',')
-        self.pa_inc = opts["FITSParAngleIncDeg"]
-        self.time_inc = opts["DtBeamMin"]
-        self.nchan = opts["NBand"]
-        self.feedangle = opts["FeedAngle"]
-        self.applyrotation = False # Handled by Cubical ParallacticMachine after visibilities have been predicted
-                                   # ie P . degrid(E, X, E^H) . P^H
-        self.applyantidiagonal = opts["FlipVisibilityHands"]
-        self.station_positions = station_positions
-
-        # make masure for zenith
-        self.zenith = dm.direction('AZEL','0deg','90deg')
-        # make position measure from antenna 0
-        # NB: in the future we may want to treat position of each antenna separately. For
-        # a large enough array, the PA w.r.t. each antenna may change! But for now, use
-        # the PA of the first antenna for all calculations
-        self.pos0 = dm.position('itrf',*[ dq.quantity(x,'m') for x in self.station_positions[0] ]) 
-
-        # make direction measure from field centre
-        ra, dec = tuple(field_centre)
-        self.field_centre_radec = tuple([ra, dec])
-        self.field_centre = dm.direction('J2000',dq.quantity(ra,"rad"),dq.quantity(dec,"rad"))
-
-        # get channel frequencies from MS
-        self.freqs = chunk_ctr_frequencies.ravel()
-        if not self.nchan:
-            self.nchan = len(self.freqs)
-        else:
-            cw = chunk_channel_widths.ravel()          
-            fq = np.linspace(self.freqs[0]-cw[0]/2, self.freqs[-1]+cw[-1]/2, self.nchan+1)
-            self.freqs = (fq[:-1] + fq[1:])/2
-
-        feed = opts["FITSFeed"]
-        if feed:
-            if len(feed) != 2:
-                raise ValueError("FITSFeed parameter must be two characters (e.g. 'xy')")
-            feed = feed.lower()
-            if "x" in feed:
-                self.feedbasis = "linear"
-            else:
-                self.feedbasis = "circular"
-            self.corrs = [ a+b for a in feed for b in feed ]
-            print("polarization basis specified by FITSFeed parameter: %s"%" ".join(self.corrs), file=log)
-        else:
-            # NB: need to check correlation names better. This assumes four correlations in that order!
-            if set(correlation_ids) <= set([MS_STOKES_ENUMS.index(c) for c in LINEAR_CORRS]):
-                self.corrs = "xx","xy","yx","yy"
-                self.feedbasis = "linear"
-                print("polarization basis is linear (MS corrs: %s)"%" ".join([MS_STOKES_ENUMS[c] for c in correlation_ids]), file=log)
-            elif set(correlation_ids) <= set([MS_STOKES_ENUMS.index(c) for c in CIRCULAR_CORRS]):
-                self.corrs = "rr","rl","lr","ll"
-                self.feedbasis = "circular"
-                print("polarization basis is circular (MS corrs: %s)"%" ".join([MS_STOKES_ENUMS[c] for c in correlation_ids]), file=log)
-            else:
-                raise RuntimeError("FITS interpolator currently only support linear or circular correlations.")
-                
-        if opts["FITSFeedSwap"]:
-            print("swapping feeds as per FITSFeedSwap setting", file=log)
-            self._feed_swap_map = dict(x="y", y="x", r="l", l="r")
-        else:
-            self._feed_swap_map = None
-        # Following code is nicked from Cattery/Siamese/OMS/pybeams_fits.py
-        REALIMAG = dict(re="real",im="imag");
-
-        # get the Cattery: if an explicit path to Cattery set, use this and import Siamese directly
-        explicit_cattery = False
-        for varname in "CATTERY_PATH","MEQTREES_CATTERY_PATH":
-            if varname in os.environ:
-                sys.path.append(os.environ[varname])
-                explicit_cattery = True
-
-        if explicit_cattery:
-            import Siamese.OMS.Utils as Utils
-            import Siamese
-            import Siamese.OMS.InterpolatedBeams as InterpolatedBeams
-            print("explicit Cattery path set: using custom Siamese module from %s"%os.path.dirname(Siamese.__file__), file=log)
-        else:
-            import Cattery.Siamese.OMS.Utils as Utils
-            import Cattery.Siamese as Siamese
-            import Cattery.Siamese.OMS.InterpolatedBeams as InterpolatedBeams
-            print("using standard Cattery.Siamese module from %s"%os.path.dirname(Siamese.__file__), file=log)
-
-        def make_beam_filename (filename_pattern,corr,reim):
-            """Makes beam filename for the given correlation and real/imaginary component (one of "re" or "im")"""
-            return Utils.substitute_pattern(filename_pattern,
-                      corr=corr.lower(),xy=corr.lower(),CORR=corr.upper(),XY=corr.upper(),
-                      reim=reim.lower(),REIM=reim.upper(),ReIm=reim.title(),
-                      realimag=REALIMAG[reim].lower(),REALIMAG=REALIMAG[reim].upper(),
-                      RealImag=REALIMAG[reim].title());
-
-        self.vbs = {}
-
-        # now, self.beamsets specifies a list of filename patterns. We need to find the one with the closest
-        # frequency coverage
-
-        if isinstance(opts["FITSFile"], str) and opts["FITSFile"].upper() == "UNITY":
-            self.use_unity_ejones = True
-        else:
-            self.use_unity_ejones = False
-            for corr in self.corrs:
-                beamlist = []
-                corr1 = "".join([self._feed_swap_map[x] for x in corr])if self._feed_swap_map else corr
-                for beamset in self.beamsets:
-                    filenames = make_beam_filename(beamset, corr1, 're'), make_beam_filename(beamset, corr1, 'im')
-                    # get interpolator from cache, or create object
-                    vb = FITSBeamInterpolator._vb_cache.get(filenames)
-                    if vb is None:
-                        print("loading beam patterns %s %s" % filenames, file=log)
-                        FITSBeamInterpolator._vb_cache[filenames] = vb = InterpolatedBeams.LMVoltageBeam(
-                            verbose=opts["FITSVerbosity"],
-                            l_axis=opts["FITSLAxis"], m_axis=opts["FITSMAxis"]
-                        )  # verbose, XY must come from options
-                        vb.read(*filenames)
-                    else:
-                        print("beam patterns %s %s already in memory" % filenames, file=log)
-                    # find frequency "distance". If beam frequency range completely overlaps MS frequency range,
-                    # this is 0, otherwise a positive number
-                    distance = max(vb._freqgrid[0] - self.freqs[0], 0) + \
-                               max(self.freqs[-1] - vb._freqgrid[-1], 0)
-                    beamlist.append((distance, vb, filenames))
-                # select beams with smallest distance
-                dist0, vb, filenames = sorted(beamlist)[0]
-                if len(beamlist) > 1:
-                    if dist0 == 0:
-                        print("beam patterns %s %s overlap the frequency coverage" % filenames, file=log)
-                    else:
-                        print("beam patterns %s %s are closest to the frequency coverage (%.1f MHz max separation)" % (
-                                        filenames[0], filenames[1], dist0*1e-6), file=log)
-                    print("  MS coverage is %.1f to %.1f GHz, beams are %.1f to %.1f MHz"%(
-                        self.freqs[0]*1e-6, self.freqs[-1]*1e-6, vb._freqgrid[0]*1e-6, vb._freqgrid[-1]*1e-6), file=log)
-                self.vbs[corr] = vb
-
-
-    _vb_cache = {}
-
-    def getBeamSampleTimes (self, times, quiet=False):
-        """For a given list of timeslots, returns times at which the beam must be sampled"""
-        if not quiet:
-            print("computing beam sample times for %d timeslots"%len(times), file=log)
-        dt = self.time_inc*60
-        beam_times = [ times[0] ]
-        for t in times[1:]:
-            if t - beam_times[-1] >= dt:
-                beam_times.append(t)
-        if not quiet:
-            print("  DtBeamMin=%.2f min results in %d samples"%(self.time_inc, len(beam_times)), file=log)
-        if self.pa_inc:
-            pas = [ 
-                # put antenna0 position as reference frame. NB: in the future may want to do it per antenna
-                dm.do_frame(self.pos0) and 
-                # put time into reference frame
-                dm.do_frame(dm.epoch("UTC",dq.quantity(t0,"s"))) and
-                # compute PA 
-                dm.posangle(self.field_centre,self.zenith).get_value("deg") for t0 in beam_times ]
-            pa0 = pas[0]
-            beam_times1 = [ beam_times[0] ]
-            for t, pa in zip(beam_times[1:], pas[1:]):
-                if abs(pa-pa0) >= self.pa_inc:
-                    beam_times1.append(t)
-                    pa0 = pa
-            if not quiet:
-                print("  FITSParAngleIncrement=%.2f deg results in %d samples"%(self.pa_inc, len(beam_times1)), file=log)
-            beam_times = beam_times1
-        beam_times.append(times[-1]+1)
-        return beam_times
-
-    def getFreqDomains (self):
-        domains = np.zeros((len(self.freqs),2),np.float64)
-        df = (self.freqs[1]-self.freqs[0])/2 if len(self.freqs)>1 else self.freqs[0]
-        domains[:,0] = self.freqs-df
-        domains[:,1] = self.freqs+df
-#        import pdb; pdb.set_trace()
-        return domains
-
-    def radec2lm_scalar(self,ra,dec):
-        """ 
-            SIN projected world to l,m projection 
-            AIPS memo series, 27
-            Eric Greisen
-        """
-        ra0, dec0 = self.field_centre_radec
-        l = np.cos(dec) * np.sin(ra - ra0)
-        m = np.sin(dec) * np.cos(dec0) - np.cos(dec) * np.sin(dec0) * np.cos(ra - ra0)
-        return l,m
-
-    def evaluateBeam (self, t0, ra, dec):
-        """Evaluates beam at time t0, in directions ra, dec.
-        Inputs: t0 is a single time. ra, dec are Ndir vectors of directions.
-        Output: a complex array of shape [Ndir,Nant,Nfreq,2,2] giving the Jones matrix per antenna, direction and frequency
-        """
-
-        # put antenna0 position as reference frame. NB: in the future may want to do it per antenna
-        dm.do_frame(self.pos0);
-        # put time into reference frame
-        dm.do_frame(dm.epoch("UTC",dq.quantity(t0,"s")))
-        # compute PA 
-        parad = dm.posangle(self.field_centre,self.zenith).get_value("rad")
-        import math
-        # print("time %f, position angle %f"%(t0, parad*180/math.pi), file=log)
-
-        # compute l,m per direction
-        ndir = len(ra)
-        l0 = numpy.zeros(ndir,float)
-        m0 = numpy.zeros(ndir,float)
-        for i,(r1,d1) in enumerate(zip(ra,dec)):
-            l0[i], m0[i] = self.radec2lm_scalar(r1,d1)
-        # print(ra*180/np.pi,dec*180/np.pi, file=log)
-        # print(l0*180/np.pi,m0*180/np.pi, file=log)
-        # rotate each by parallactic angle
-        r = numpy.sqrt(l0*l0+m0*m0)
-        angle = numpy.arctan2(m0,l0)
-        l = r*numpy.cos(angle + parad + np.deg2rad(self.feedangle))
-        m = r*numpy.sin(angle + parad + np.deg2rad(self.feedangle))
-
-
-
-        # # print("Beam evaluated for l,m", file=log)
-        # print(l, file=log)
-        # print(m, file=log)
-        # print("time %f, position angle %f"%(t0, parad*180/math.pi), file=log)
-
-        # get interpolated values. Output shape will be [ndir,nfreq]
-        if self.use_unity_ejones:
-            beamjones = [ np.ones([ndir, len(self.freqs)], dtype=numpy.complex64),
-                          np.zeros([ndir, len(self.freqs)], dtype=numpy.complex64),
-                          np.zeros([ndir, len(self.freqs)], dtype=numpy.complex64),
-                          np.ones([ndir, len(self.freqs)], dtype=numpy.complex64) ]
-        else:
-            beamjones = [ self.vbs[corr].interpolate(l,m,freq=self.freqs,freqaxis=1) for corr in self.corrs ]
-
-        # now make output matrix
-
-        jones = numpy.zeros((ndir,self.station_positions.shape[0],len(self.freqs),2,2),dtype=numpy.complex64)
-        # populate it with values
-        # NB: here we copy the same Jones to every antenna. In principle we could compute
-        # a parangle per antenna. When we have pointing error, it's also going to be per
-        # antenna
-        for iant in range(self.station_positions.shape[0]):
-            for ijones,(ix,iy) in enumerate(((0,0),(0,1),(1,0),(1,1))):
-                bj = beamjones[ijones]
-                jones[:,iant,:,ix,iy] = beamjones[ijones].reshape((len(bj),1)) if bj.ndim == 1 else bj
-
-        feedswap_jones = np.array([[1., 0.], [0., 1.]], dtype=numpy.complex64)
-        if self.applyantidiagonal:
-            feedswap_jones = np.array([[0., 1.], [1., 0.]], dtype=numpy.complex64)
-
-        Pjones = np.array([[1., 0.], [0., 1.]], dtype=numpy.complex64)
-        if self.applyrotation:
-            print("Applying derotation to data, since beam is sampled in time. "
-                  "If you have equatorial mounts this is not what you should be doing!", file=log)
-            if self.feedbasis == "linear":
-                """ 2D rotation matrix according to Hales, 2017: 
-                Calibration Errors in Interferometric Radio Polarimetry """
-                c1, s1 = np.cos(parad + np.deg2rad(self.feedangle)), np.sin(parad + np.deg2rad(self.feedangle))
-                # assume all stations has same parallactic angle
-                Pjones[0, 0] = c1
-                Pjones[0, 1] = s1
-                Pjones[1, 0] = -s1
-                Pjones[1, 1] = c1
-            elif self.feedbasis == "circular":
-                """ phase rotation matrix according to Hales, 2017: 
-                Calibration Errors in Interferometric Radio Polarimetry """
-                e1 = np.exp(1.0j * -(parad + np.deg2rad(self.feedangle)))
-                e2 = np.exp(1.0j * (parad + np.deg2rad(self.feedangle)))
-                # assume all stations has same parallactic angle
-                Pjones[0, 0] = e1
-                Pjones[0, 1] = 0
-                Pjones[1, 0] = 0
-                Pjones[1, 1] = e2
-            else:
-                raise RuntimeError("Feed basis not supported")
-
-        # dot diagonal block matrix of P with E diagonal block vector 
-        # again assuming constant P matrix across all stations
-        E_vec = jones.reshape(ndir * self.station_positions.shape[0] * len(self.freqs), 2, 2)
-        for i in range(E_vec.shape[0]):
-            E_vec[i,:,:] = np.dot(Pjones, np.dot(E_vec[i, :, :], feedswap_jones))
-
-        return E_vec.reshape(ndir, self.station_positions.shape[0], len(self.freqs), 2, 2)
-
-
-
-
+        self.__ms = DDFacetMSLite(field_centre,
+                                  chunk_ctr_frequencies,
+                                  chunk_channel_widths,
+                                  correlation_ids,
+                                  station_positions,
+                                  station_names)
+        self.__opts = opts
+        self.__vbinterpolator = DDFacetFITSBeam.ClassFITSBeam(self.__ms, self.__opts)
+        for method in ('evaluateBeam', 'getFreqDomains', 'getBeamSampleTimes'):
+            setattr(self, method, getattr(self.__vbinterpolator, method))
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -88,8 +88,8 @@ setup(name='cubical',
       entry_points={'console_scripts': ['gocubical = cubical.main:main']},
       extras_require={
           'lsm-support': ['montblanc >= 0.6.4'],
-          'degridder-support': ['ddfacet >= 0.6.0', 
+          'degridder-support': ['ddfacet >= 0.6.1', 
                                 'regions >= 0.4',
-                                'meqtrees-cattery >= 1.7.0']
+                                'meqtrees-cattery >= 1.7.7']
       }
 )


### PR DESCRIPTION
Pulls in the latest goodies from the upcoming DDFacet releases
by unifying the FITSBeam interface for the degridder

This includes provisions for supporting heterogeneous beams
across the array

As discussed with @JSKenyon this only adds this support for degridding modes. The DFT will require us to incorporate (and extend) the fused rime as replacement for montblanc. This will take extensive reworking of those modules which is beyond the scope of this simple fix.

This PR must only be merged once DDFacet with heterogeneous support is released (at least to make the documentation correct). I've already adjusted the version numbers in setup.py accordingly.