### PR TITLE
Roll back to old DS9 parser

### DIFF
--- a/cubical/degridder/DicoSourceProvider.py
+++ b/cubical/degridder/DicoSourceProvider.py
@@ -5,7 +5,7 @@ try:
 except ImportError:
     raise ImportError("Cannot import DDFacet")
 
-from regions import Regions, PolygonPixelRegion
+from regions import DS9Parser
 import numpy as np
 from .geometry import BoundingConvexHull, BoundingBox, BoundingBoxFactory
 from cubical.tools import logger, ModColor
@@ -105,14 +105,14 @@ class DicoSourceProvider(object):
         """
         clusters = []
         if fn is not None: # dde case
-            shapes = Regions.read(fn)
-            if not all([type(reg) is PolygonPixelRegion for reg in shapes]):
-                raise RuntimeError("Currently only supports regions of type 'polygon' with 'physical' (pixel) coordinates as input regions")
-            for regi, reg in enumerate(shapes):
-                coords = np.array(list(zip(map(int, reg.vertices.x), 
-                                            map(int, reg.vertices.y))))
-                clusters.append(BoundingConvexHull(coords,
-                                                    name="DDE_REG{0:d}".format(regi + 1)))
+            with open(fn) as f:
+                parser = DS9Parser(f.read())
+                for regi, reg in enumerate(parser.shapes):
+                    coords = list(map(int, [c.value for c in reg.coord]))
+                    assert len(coords) % 2 == 0, "Number of region coords must be multiple of 2-tuple"
+                    coords = np.array(coords).reshape([len(coords) // 2, 2])
+                    clusters.append(BoundingConvexHull(coords,
+                                                       name="DDE_REG{0:d}".format(regi + 1)))
         else: # die case
             clusters = [BoundingBox(0,
                                     self.__nx - 1,

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ setup(name='cubical',
       extras_require={
           'lsm-support': ['montblanc >= 0.6.4'],
           'degridder-support': ['ddfacet >= 0.6.0', 
-                                'regions >= 0.4',
+                                'regions < 0.5', # bug in new DS9 parser
                                 'meqtrees-cattery >= 1.7.0']
       }
 )


### PR DESCRIPTION
I'm rolling back to the old DS9 parser due to breakage in the new regions ds9 parser
